### PR TITLE
add namespace affine

### DIFF
--- a/resources/namespaces/env/k3s-cluster/templates/affine.yaml
+++ b/resources/namespaces/env/k3s-cluster/templates/affine.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  creationTimestamp: null
+  name: affine
+spec: {}
+status: {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Kubernetes `Namespace` manifest for `affine` in the k3s cluster, annotated to disable Argo CD pruning.
> 
> - **Kubernetes / Infra**:
>   - Add `Namespace` manifest `resources/namespaces/env/k3s-cluster/templates/affine.yaml`.
>     - Sets `metadata.name: affine`.
>     - Adds annotation `argocd.argoproj.io/sync-options: Prune=false` to disable pruning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc369266dcec46bcf168d73df5b82eee678d199c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->