### PR TITLE
add namespace pgvector, add pv/pvc for affine

### DIFF
--- a/resources/app-volumes/env/k3s-cluster/templates/affine-pv.yaml
+++ b/resources/app-volumes/env/k3s-cluster/templates/affine-pv.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: affine-pv
+  namespace: affine
+  labels:
+    type: local
+spec:
+  storageClassName: local-path
+  volumeMode: Filesystem
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: "/mnt/nfs/AppData/affine-cluster"
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: affine-pvc
+    namespace: affine
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - k3s-cluster-node-x

--- a/resources/app-volumes/env/k3s-cluster/templates/affine-pvc.yaml
+++ b/resources/app-volumes/env/k3s-cluster/templates/affine-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: affine-pvc
+  namespace: affine
+  labels:
+    name: affine-pvc
+spec:
+  storageClassName: local-path
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/resources/namespaces/env/k3s-cluster/templates/pgvector.yaml
+++ b/resources/namespaces/env/k3s-cluster/templates/pgvector.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  creationTimestamp: null
+  name: pgvector
+spec: {}
+status: {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add PersistentVolume/PersistentVolumeClaim for affine and create pgvector namespace.
> 
> - **Kubernetes resources**:
>   - **Affine storage**:
>     - Add `PersistentVolume` `affine-pv` in `resources/app-volumes/env/k3s-cluster/templates/affine-pv.yaml` (100Gi, `local-path`, `Retain`, `local` path `/mnt/nfs/AppData/affine-cluster`, node affinity, `claimRef` to `affine-pvc`).
>     - Add `PersistentVolumeClaim` `affine-pvc` in `resources/app-volumes/env/k3s-cluster/templates/affine-pvc.yaml` (100Gi, `local-path`, `ReadWriteOnce`).
>   - **Namespaces**:
>     - Create `pgvector` namespace in `resources/namespaces/env/k3s-cluster/templates/pgvector.yaml` with Argo CD sync option `Prune=false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f29197e2b92b48e6f7c8a1f8e912b39da59a9d27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->